### PR TITLE
Refactor Product for easier saving

### DIFF
--- a/src/php/Product.php
+++ b/src/php/Product.php
@@ -75,7 +75,7 @@ abstract class Product
      */
     private static function withPdo(): \PDO
     {
-        return self::$pdo ?? die('self::$pdo is not set!');
+        return self::$pdo ?? Util::throwError('self::$pdo is not set!');
     }
 
     public static function setPdo(\PDO $pdo)
@@ -90,11 +90,11 @@ abstract class Product
     protected function extraAttributesQuery(): string
     {
         if (!static::EXTRA_ATTRIBUTE_TABLE_NAME) {
-            die('EXTRA_ATTRIBUTE_TABLE_NAME is not defined!');
+            Util::throwError('EXTRA_ATTRIBUTE_TABLE_NAME is not defined!');
         }
 
         if (!static::EXTRA_ATTRIBUTE_COLUMN_COUNT) {
-            die('EXTRA_ATTRIBUTE_COLUMN_COUNT is not defined!');
+            Util::throwError('EXTRA_ATTRIBUTE_COLUMN_COUNT is not defined!');
         }
 
         return Util::formatInsertQuery(
@@ -118,16 +118,9 @@ abstract class Product
             $this->getExtraAttributeArgs(),
         );
 
-        // TODO Hide this information in production
         if (!$statement->execute($executeArgs)) {
             // TODO Destroy Product entry here
-            echo('$statement');
-            var_dump($statement);
-            echo('executeArgs: ');
-            var_dump($executeArgs);
-            echo('error info: ');
-            var_dump($statement->errorInfo());
-            die('X failed to be created!');
+            Util::throwError('Extra attribute row creation failed!');
         } else {
             $this->extraAttributeId = self::withPdo()->lastInsertId();
         }
@@ -154,12 +147,8 @@ abstract class Product
             )
         );
 
-        // TODO Hide this information in production
         if (!$statement->execute(array($this->sku, $this->name, $this->price))) {
-            print('Product failed to be created!');
-            echo('error info: ');
-            var_dump($statement->errorInfo());
-            die;
+            Util::throwError('Product failed to be created!');
         } else {
             $this->databaseId = self::withPdo()->lastInsertId();
         }
@@ -185,6 +174,6 @@ abstract class Product
     public function getDatabaseId(): int
     {
         return $this->databaseId
-            ?? die('Model has no ID because it is not saved!');
+            ?? Util::throwError('Model has no ID because it is not saved!');
     }
 }

--- a/src/php/ProductBook.php
+++ b/src/php/ProductBook.php
@@ -17,15 +17,14 @@ class ProductBook extends Product
     private $weight;
 
     public function __construct(
-        \PDO $pdo,
         string $sku,
         string $name,
         int $price,
         float $weight
     ) {
-        parent::__construct($pdo, $sku, $name, $price);
+        parent::__construct($sku, $name, $price);
 
-        $this->tryCreatingExtraAttributes($pdo, array($weight));
+        $this->tryCreatingExtraAttributes(array($weight));
         $this->weight = $weight;
     }
 

--- a/src/php/ProductBook.php
+++ b/src/php/ProductBook.php
@@ -6,8 +6,9 @@ use TechTask\Product\Product;
 
 class ProductBook extends Product
 {
-    protected const EXTRA_ATTRIBUTE_INSERT_QUERY
-        = 'INSERT INTO discs VALUES(null, ?, ?)';
+    protected const EXTRA_ATTRIBUTE_TABLE_NAME = 'books';
+
+    protected const EXTRA_ATTRIBUTE_COLUMN_COUNT = 3;
 
     private $bookDataId;
 

--- a/src/php/ProductBook.php
+++ b/src/php/ProductBook.php
@@ -23,9 +23,12 @@ class ProductBook extends Product
         float $weight
     ) {
         parent::__construct($sku, $name, $price);
-
-        $this->tryCreatingExtraAttributes(array($weight));
         $this->weight = $weight;
+    }
+
+    protected function getExtraAttributeArgs(): array
+    {
+        return array($this->weight);
     }
 
     public function toJson()

--- a/src/php/ProductDisc.php
+++ b/src/php/ProductDisc.php
@@ -21,9 +21,12 @@ class ProductDisc extends Product
         int $discSize
     ) {
         parent::__construct($sku, $name, $price);
-
-        $this->tryCreatingExtraAttributes(array($discSize));
         $this->discSize = $discSize;
+    }
+
+    protected function getExtraAttributeArgs(): array
+    {
+        return array($this->discSize);
     }
 
     public function toJson()

--- a/src/php/ProductDisc.php
+++ b/src/php/ProductDisc.php
@@ -6,8 +6,9 @@ use TechTask\Product\Product;
 
 class ProductDisc extends Product
 {
-    protected const EXTRA_ATTRIBUTE_INSERT_QUERY
-        = 'INSERT INTO discs VALUES(null, ?, ?)';
+    protected const EXTRA_ATTRIBUTE_TABLE_NAME = 'discs';
+
+    protected const EXTRA_ATTRIBUTE_COLUMN_COUNT = 3;
 
     /**
      * Disc size in MB.

--- a/src/php/ProductDisc.php
+++ b/src/php/ProductDisc.php
@@ -15,15 +15,14 @@ class ProductDisc extends Product
     private $discSize;
 
     public function __construct(
-        \PDO $pdo,
         string $sku,
         string $name,
         int $price,
         int $discSize
     ) {
-        parent::__construct($pdo, $sku, $name, $price);
+        parent::__construct($sku, $name, $price);
 
-        $this->tryCreatingExtraAttributes($pdo, array($discSize));
+        $this->tryCreatingExtraAttributes(array($discSize));
         $this->discSize = $discSize;
     }
 

--- a/src/php/ProductFurniture.php
+++ b/src/php/ProductFurniture.php
@@ -33,12 +33,14 @@ class ProductFurniture extends Product
         int $length
     ) {
         parent::__construct($sku, $name, $price);
-
-        $this->tryCreatingExtraAttributes(array($height, $width, $length));
-
         $this->height = $height;
         $this->width = $width;
         $this->length = $length;
+    }
+
+    protected function getExtraAttributeArgs(): array
+    {
+        return array($this->height, $this->width, $this->length);
     }
 
     public function toJson()

--- a/src/php/ProductFurniture.php
+++ b/src/php/ProductFurniture.php
@@ -6,8 +6,9 @@ use TechTask\Product\Product;
 
 class ProductFurniture extends Product
 {
-    protected const EXTRA_ATTRIBUTE_INSERT_QUERY
-        = 'INSERT INTO furniture VALUES(null, ?, ?, ?, ?)';
+    protected const EXTRA_ATTRIBUTE_TABLE_NAME = 'furniture';
+
+    protected const EXTRA_ATTRIBUTE_COLUMN_COUNT = 5;
 
     /**
      * Furniture height in cm.

--- a/src/php/ProductFurniture.php
+++ b/src/php/ProductFurniture.php
@@ -25,7 +25,6 @@ class ProductFurniture extends Product
     private $length;
 
     public function __construct(
-        \PDO $pdo,
         string $sku,
         string $name,
         int $price,
@@ -33,12 +32,9 @@ class ProductFurniture extends Product
         int $width,
         int $length
     ) {
-        parent::__construct($pdo, $sku, $name, $price);
+        parent::__construct($sku, $name, $price);
 
-        $this->tryCreatingExtraAttributes(
-            $pdo,
-            array($height, $width, $length),
-        );
+        $this->tryCreatingExtraAttributes(array($height, $width, $length));
 
         $this->height = $height;
         $this->width = $width;

--- a/src/php/Router.php
+++ b/src/php/Router.php
@@ -2,6 +2,8 @@
 
 namespace TechTask\Router;
 
+use TechTask\Util\Util;
+
 class Router
 {
     private $routeHandlers = array();
@@ -30,7 +32,7 @@ class Router
         if (array_key_exists($uri, $this->routeHandlers)) {
             $this->routeHandlers[$uri]();
         } else {
-            die("Route does not exist!");
+            Util::throwError("Route does not exist!");
         }
     }
 }

--- a/src/php/Util.php
+++ b/src/php/Util.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace TechTask\Util;
+
+/**
+ * A collection of utility functions.
+ */
+class Util
+{
+    /**
+     * Generate insert query.
+     *
+     * @param $tableName *Sanitized* table name.
+     * @param $valueCount The number of values to be inserted (including id).
+     */
+    public static function formatInsertQuery(
+        string $tableName,
+        int $valueCount
+    ): string {
+        return sprintf(
+            "INSERT INTO $tableName VALUES(%s)",
+            implode(", ", array_merge(
+                ['null'],
+                array_fill(1, $valueCount - 1, "?"),
+            )),
+        );
+    }
+}

--- a/src/php/Util.php
+++ b/src/php/Util.php
@@ -25,4 +25,18 @@ class Util
             )),
         );
     }
+
+    /**
+     * Make and throw and Exception.
+     *
+     * @see \Exception
+     */
+    public static function throwError(
+        string $message = "",
+        int $code = 0,
+        ?Throwable $previous = null
+    ) {
+        // TODO Hide exception info in production
+        throw new \Exception($message, $code, $previous);
+    }
 }

--- a/src/php/views/index.php
+++ b/src/php/views/index.php
@@ -1,9 +1,10 @@
 <?php
 
 use Dotenv\Dotenv;
-use TechTask\ProductDisc;
-use TechTask\ProductBook;
-use TechTask\ProductFurniture;
+use TechTask\Product\Product;
+use TechTask\ProductDisc\ProductDisc;
+use TechTask\ProductBook\ProductBook;
+use TechTask\ProductFurniture\ProductFurniture;
 use TechTask\Router\Router;
 
 $pdo = new PDO(
@@ -12,23 +13,22 @@ $pdo = new PDO(
     $_ENV['DB_PASSWORD'],
 );
 
+Product::setPdo($pdo);
+
 $products = array(
-    new ProductDisc\ProductDisc(
-        $pdo,
+    new ProductDisc(
         "DSC123123",
         "Copyrighted music",
         199,
         1000
     ),
-    new ProductBook\ProductBook(
-        $pdo,
+    new ProductBook(
         "BKK123123",
         "Learn PHP in 24 hours",
         23.99,
         0.5
     ),
-    new ProductFurniture\ProductFurniture(
-        $pdo,
+    new ProductFurniture(
         "FNT123123",
         "Wooden box",
         99.99,

--- a/src/php/views/index.php
+++ b/src/php/views/index.php
@@ -38,6 +38,10 @@ $products = array(
     ),
 );
 
+foreach($products as $product) {
+    $product->save();
+}
+
 ?>
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
The main reason for this PR is to make it possible for Product object to be created without automatically saving it to the database. It is required for converting an existing database row into a model.